### PR TITLE
Add setting for AI model and version

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
-	"id": "ai-summary",
-	"name": "AI Notes Summary",
-	"version": "1.0.3",
-	"minAppVersion": "0.15.0",
-	"description": "Summarize referenced notes using OpenAI.",
-	"author": "R. Ian Bull",
-	"authorUrl": "https://ianbull.com",
-	"isDesktopOnly": true
+  "id": "ai-summary",
+  "name": "AI Notes Summary",
+  "version": "1.0.4",
+  "minAppVersion": "0.15.0",
+  "description": "Summarize referenced notes using OpenAI.",
+  "author": "R. Ian Bull",
+  "authorUrl": "https://ianbull.com",
+  "isDesktopOnly": true
 }

--- a/src/gpt.ts
+++ b/src/gpt.ts
@@ -8,8 +8,9 @@ interface GPTResponse {
 export async function promptGPTChat(
   prompt: string,
   apiKey: string,
+  model: string,
   maxTokens: number,
-  dialog: ResultDialog,
+  dialog: ResultDialog
 ) {
   const requestOptions = {
     method: "POST",
@@ -18,8 +19,8 @@ export async function promptGPTChat(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      "messages": [{ "role": "system", "content": prompt }],
-      model: "gpt-3.5-turbo",
+      messages: [{ role: "system", content: prompt }],
+      model: model,
       temperature: 0.7,
       max_tokens: maxTokens,
       top_p: 1,
@@ -30,7 +31,8 @@ export async function promptGPTChat(
   };
 
   const response = await fetch(url, requestOptions);
-  const reader = response.body?.pipeThrough(new TextDecoderStream())
+  const reader = response.body
+    ?.pipeThrough(new TextDecoderStream())
     .getReader();
   let content = "";
   let gotDoneMessage = false;


### PR DESCRIPTION
This change allows a user to choose between various ChatGPT models. There's a dropdown added to the settings page, with the default continuing as gpt-3.5-turbo. 

Adding new models is easy to do with only additions required to line 204 in main.ts..

P.S. I'm not a ts developer, so please don't hesitate to suggest changes.